### PR TITLE
Don't crash on merging empty objects in the Java runtime

### DIFF
--- a/java/runtime/src/main/java/org/adl/runtime/JsonHelpers.java
+++ b/java/runtime/src/main/java/org/adl/runtime/JsonHelpers.java
@@ -18,6 +18,7 @@ import java.net.URL;
 import java.nio.charset.Charset;
 
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Simple functions to reduce boilerplate in working with json for ADL values
@@ -168,13 +169,13 @@ public class JsonHelpers {
       JsonObject result = new JsonObject();
       String lastMergedField = null;
 
-      for(Map.Entry<String,JsonElement> me : jv1.getAsJsonObject().entrySet()) {
+      for(Map.Entry<String,JsonElement> me : jobj1.entrySet()) {
         if (!me.getKey().equals(LAST_MERGED_FIELD)) {
           result.add(me.getKey(), me.getValue());
           lastMergedField = me.getKey();
         }
       }
-      for(Map.Entry<String,JsonElement> me : jv2.getAsJsonObject().entrySet()) {
+      for(Map.Entry<String,JsonElement> me : jobj2.entrySet()) {
         if (!me.getKey().equals(LAST_MERGED_FIELD)) {
           if (result.has(me.getKey())) {
             result.add(me.getKey(), mergeJson(result.get(me.getKey()), me.getValue()));
@@ -184,7 +185,10 @@ public class JsonHelpers {
           lastMergedField = me.getKey();
         }
       }
-      result.add(LAST_MERGED_FIELD, new JsonPrimitive(lastMergedField));
+
+      if (Objects.nonNull(lastMergedField)) {
+        result.add(LAST_MERGED_FIELD, new JsonPrimitive(lastMergedField));
+      }
       return result;
     } else {
       return jv2;

--- a/java/tests/src/test/java/TestMerging.java
+++ b/java/tests/src/test/java/TestMerging.java
@@ -17,6 +17,7 @@ import org.adl.runtime.JsonHelpers;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 
 import adl.test2.S1;
 import adl.test5.U8;
@@ -76,6 +77,13 @@ public class TestMerging {
     assertEquals(U9.Disc.V1, s.getF1().getDisc());
     assertEquals("aa", s.getF1().getV1());
     assertEquals(U9.Disc.V3, s.getF2().getDisc());
+  }
+
+  @Test
+  public void testMergeEmptyObjects() {
+    // Shouldn't crash.
+    JsonElement empty = JsonHelpers.mergeJson(new JsonObject(), new JsonObject());
+    assertEquals(gson.toJson(empty), "{}");
   }
 
   static Gson gson = new GsonBuilder()


### PR DESCRIPTION
Classic NPE.