### PR TITLE
proposed adl for adl workspace definitions

### DIFF
--- a/adl.workspace.json
+++ b/adl.workspace.json
@@ -1,0 +1,6 @@
+{
+    "uses": [
+        "./adl/stdlib",
+        "./haskell/compiler/lib/adl"
+    ]
+}

--- a/adl/stdlib/sys/workspace.adl
+++ b/adl/stdlib/sys/workspace.adl
@@ -1,0 +1,12 @@
+module sys.workspace {
+
+/// Metadata contained in a file named `adl.workspace.json`.
+/// Used be ADL tooling (adl-lsp, aldc, etc.)
+struct AdlWorkspace {
+  Vector<RelDirPath> uses = [];
+};
+
+/// A relative directory path, used to refer to subdirectories containing an ADL bundle.
+type RelDirPath = String;
+
+};

--- a/haskell/tools/scratch-build.sh
+++ b/haskell/tools/scratch-build.sh
@@ -24,6 +24,7 @@ adlcb -I $CONFIG_ADL_DIR -O compiler/adlc-lib1 $CONFIG_ADL_DIR/rust.adl
 # Generate ADL specified elements of the haskell runtime
 adlcb -O runtime/src $ADL_STDLIB_DIR/sys/types.adl
 adlcb -O runtime/src $ADL_STDLIB_DIR/sys/adlast.adl
+adlcb -O runtime/src $ADL_STDLIB_DIR/sys/workspace.adl
 
 # Build and test the compiler itself
 stack build --test adl-compiler 
@@ -38,15 +39,15 @@ stack exec adlc -- typescript \
  --ts-style template \
  -O ../typescript/runtime/embedded \
  -I $ADL_STDLIB_DIR \
- $ADL_STDLIB_DIR/sys/types.adl $ADL_STDLIB_DIR/sys/adlast.adl $ADL_STDLIB_DIR/sys/dynamic.adl
-stack exec adlc -- typescript \
+ $ADL_STDLIB_DIR/sys/types.adl $ADL_STDLIB_DIR/sys/adlast.adl $ADL_STDLIB_DIR/sys/workspace.adl $ADL_STDLIB_DIR/sys/dynamic.adl
+ stack exec adlc -- typescript \
  --no-overwrite \
  --exclude-ast \
  --verbose \
  --ts-style deno \
  -O ../typescript/runtime/published/src \
  -I $ADL_STDLIB_DIR \
- $ADL_STDLIB_DIR/sys/types.adl $ADL_STDLIB_DIR/sys/adlast.adl $ADL_STDLIB_DIR/sys/dynamic.adl
+ $ADL_STDLIB_DIR/sys/types.adl $ADL_STDLIB_DIR/sys/adlast.adl $ADL_STDLIB_DIR/sys/workspace.adl $ADL_STDLIB_DIR/sys/dynamic.adl
 
 # Generate ADL specified elements of the c++ runtime
 CPP_RUNTIME_DIR=../cpp/runtime/src-generated 
@@ -56,7 +57,7 @@ stack exec adlc -- cpp \
  --include-prefix adl \
  -O $CPP_RUNTIME_DIR \
  -I $ADL_STDLIB_DIR \
- $ADL_STDLIB_DIR/sys/types.adl $ADL_STDLIB_DIR/sys/adlast.adl $ADL_STDLIB_DIR/sys/dynamic.adl
+ $ADL_STDLIB_DIR/sys/types.adl $ADL_STDLIB_DIR/sys/adlast.adl  $ADL_STDLIB_DIR/sys/workspace.adl $ADL_STDLIB_DIR/sys/dynamic.adl
 
 # Run some tests for each target language
 stack build generated-tests


### PR DESCRIPTION
Here's the proposed ADL for defining ADL workspace meta information.
The idea is that, if a file `adl.workspace.json` is present at the root of a directory of a repository, tooling (at this point adl-lsp) would use it to discover parent directories of ADL code.
For the lsp;
- running in vscode, this would replace the `adl.packageRoots` extension config.
- helix edit, replace `roots` config
- vim, replace `root_markers`

This is orthogonal to @timbod7 proposal for packages definitions.
Workspace and package definitions, could be valuable in combination, specifically if the package definitions holds a url to globally unique location for an ADL package (the workspace would indicated to ignore the global location).
