### PR TITLE
fix: 'adlc java --include-rt' sysmodule resolution

### DIFF
--- a/haskell/compiler/src/ADL/Compiler/Backends/Java.hs
+++ b/haskell/compiler/src/ADL/Compiler/Backends/Java.hs
@@ -830,7 +830,7 @@ snJavaGenerate = ScopedName (ModuleName ["adlc","config","java"]) "JavaGenerate"
 
 sysModules :: [ModuleName]
 sysModules = [
-               ModuleName ["sys", "types.adl"],
-               ModuleName ["sys", "dynamic.adl"],
-               ModuleName ["sys", "adlast.adl"]
+               ModuleName ["sys", "types"],
+               ModuleName ["sys", "dynamic"],
+               ModuleName ["sys", "adlast"]
              ]


### PR DESCRIPTION
fix for bug in adlc version 1.3.0 for the java generator.
The following works
`adlc java -I adl -O java --manifest=java/.adl-manifest empty_module`
this fails
`adlc java --include-rt -I adl -O java --manifest=java/.adl-manifest empty_module`
with the error message
`Unable to find module 'sys.types.adl'`